### PR TITLE
Adds all proponents to issue

### DIFF
--- a/assets/definitions.json
+++ b/assets/definitions.json
@@ -26,14 +26,6 @@
         },
         {
             "arguments": {},
-            "destination": "issue.add.proponents-count",
-            "destination_type": "queue",
-            "routing_key": "congressman-document.*",
-            "source": "service",
-            "vhost": "/"
-        },
-        {
-            "arguments": {},
             "destination": "document.add",
             "destination_type": "queue",
             "routing_key": "document.*",
@@ -164,13 +156,6 @@
             "auto_delete": false,
             "durable": true,
             "name": "issue.add",
-            "vhost": "/"
-        },
-        {
-            "arguments": {},
-            "auto_delete": false,
-            "durable": true,
-            "name": "issue.add.proponents-count",
             "vhost": "/"
         },
         {

--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,7 @@ add congressman to document
         +- congressman-document.*:[congressman-document.add] -> `document-congressman.addProponentDocument` 
         |           - Add proponent(s) to Document
         |
-        +- congressman-document.*:[congressman-document.add.proponent] -> `document-congressman.addProponentIssue`
-        |           - Add proponent to Issue (if primary document)
-        |
-        `- congressman-document.*:[issue.add.proponents-count] -> `document-congressman.addProponentCountIssue`
-                    - Add proponents count to Issue
+        `- congressman-document.*:[congressman-document.add.proponent] -> `document-congressman.addProponentIssue`
+                    - Add proponent to Issue (if primary document)
 
 ```

--- a/src/__tests__/actions/document-congressman.spec.ts
+++ b/src/__tests__/actions/document-congressman.spec.ts
@@ -142,7 +142,15 @@ describe('addProponentIssue', () => {
             abbr_long: 'string',
             color: null
         },
-        '/samantekt/loggjafarthing/148/thingmal/2/thingskjol/1/thingmenn': 2
+        '/samantekt/loggjafarthing/148/thingmal/2/thingskjol/1/thingmenn': [{
+            document_id: 1,
+            issue_id: 2,
+            category: 'A',
+            assembly_id: 148,
+            congressman_id: 652,
+            minister: null,
+            order: 1
+        }]
     });
 
     beforeAll(async () => {
@@ -174,8 +182,10 @@ describe('addProponentIssue', () => {
             'issue.category': message.body.category,
         });
 
-        expect(issue.proponent.hasOwnProperty('congressman')).toBe(true);
-        expect(issue.proponent.hasOwnProperty('constituency')).toBe(true);
-        expect(issue.proponent.hasOwnProperty('party')).toBe(true);
+        expect(issue.proponents).toBeInstanceOf(Array);
+
+        // expect(issue.proponent.hasOwnProperty('congressman')).toBe(true);
+        // expect(issue.proponent.hasOwnProperty('constituency')).toBe(true);
+        // expect(issue.proponent.hasOwnProperty('party')).toBe(true);
     })
 });

--- a/src/__tests__/actions/document-congressman.spec.ts
+++ b/src/__tests__/actions/document-congressman.spec.ts
@@ -1,7 +1,7 @@
 import {CongressmanDocument, Message} from "../../../@types";
 import MongoMock from "../Mongo";
 import ApiServer from "../Server";
-import {addProponentCountIssue, addProponentDocument, addProponentIssue} from '../../actions/document-congressman'
+import {addProponentDocument, addProponentIssue} from '../../actions/document-congressman'
 
 describe('addProponentDocument', () => {
     const mongo = new MongoMock();
@@ -177,70 +177,5 @@ describe('addProponentIssue', () => {
         expect(issue.proponent.hasOwnProperty('congressman')).toBe(true);
         expect(issue.proponent.hasOwnProperty('constituency')).toBe(true);
         expect(issue.proponent.hasOwnProperty('party')).toBe(true);
-    })
-});
-
-describe('addProponentCountIssue', () => {
-    const mongo = new MongoMock();
-    const server = ApiServer({
-        '/samantekt/loggjafarthing/148/thingmal/2/thingskjol/1': {
-            document_id: 1,
-            issue_id: 2,
-            category: "A",
-            assembly_id: 148,
-            date: "2017-12-14 16:03:00",
-            url: "http://www.althingi.is/altext/148/s/0001.html",
-            type: "stjórnarfrumvarp"
-        },
-        '/samantekt/loggjafarthing/148/thingmal/2/thingskjol': [{
-            document_id: 1,
-            issue_id: 2,
-            category: "A",
-            assembly_id: 148,
-            date: "2017-12-14 16:03:00",
-            url: "http://www.althingi.is/altext/148/s/0001.html",
-            type: "stjórnarfrumvarp"
-        },{
-            document_id: 2,
-            issue_id: 2,
-            category: "A",
-            assembly_id: 148,
-            date: "2017-12-14 16:03:00",
-            url: "http://www.althingi.is/altext/148/s/0001.html",
-            type: "type"
-        }],
-        '/samantekt/loggjafarthing/148/thingmal/2/thingskjol/1/thingmenn': 2
-    });
-
-    beforeAll(async () => {
-        await mongo.open('document-congressman-addProponentCountIssue');
-    });
-
-    afterAll(async () => {
-        await mongo.close();
-    });
-
-    test('test', async () => {
-        const message: Message<CongressmanDocument> = {
-            id: '101-1-1',
-            body: {
-                document_id: 1,
-                issue_id: 2,
-                category: 'A',
-                assembly_id: 148,
-                congressman_id: 652,
-                minister: 'fjármálaráðherra',
-                order: 1
-            }
-        };
-        await addProponentCountIssue(message, mongo.db!, server);
-
-        const issue = await mongo.db!.collection('issue').findOne({
-            'issue.assembly_id': message.body.assembly_id,
-            'issue.issue_id': message.body.issue_id,
-            'issue.category': message.body.category,
-        });
-
-        expect(issue.proponentCount).toBe(2);
     })
 });

--- a/src/actions/document-congressman.ts
+++ b/src/actions/document-congressman.ts
@@ -74,7 +74,7 @@ export const addProponentIssue = async (message: Message<CongressmanDocument>, m
                         'issue.issue_id': message.body.issue_id,
                         'issue.category': message.body.category,
                     }, {
-                        $set: {proponents: proponents}
+                        $set: {proponents: proponents.slice().sort((first, second) => (first.document.order || 0) - (second.document.order || 0))}
                     }, {
                         upsert: true
                     }).then(result => {

--- a/src/actions/document-congressman.ts
+++ b/src/actions/document-congressman.ts
@@ -45,77 +45,46 @@ export const addProponentDocument = async (message: Message<CongressmanDocument>
 };
 
 /**
- * If document is the initial document and the congressman is the first proponent, then add him/her to the Issue
+ * If document is the initial document, add the proponents to the Issue
  *
  * @param message
  * @param mongo
  * @param client
  */
 export const addProponentIssue = async (message: Message<CongressmanDocument>, mongo: Db, client: HttpQuery): Promise<any> => {
-    const documents: {current: Document, all: Document[]} = await Promise.all([
+    const documents: {current: Document, all: Document[], congressmen: CongressmanDocument[]} = await Promise.all([
         client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol/${message.body.document_id}`),
         client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol`),
-    ]).then(([current, all]) => ({current, all}));
+        client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol/${message.body.document_id}/thingmenn`),
+    ]).then(([current, all, congressmen]) => ({current, all, congressmen}));
 
-    const congressman: {congressman: Congressman, constituency: Constituency, party: Party} = await Promise.all([
-        client(`/samantekt/thingmenn/${message.body.congressman_id}`),
-        client(`/samantekt/thingmenn/${message.body.congressman_id}/kjordaemi`, {dags: documents.current.date}),
-        client(`/samantekt/thingmenn/${message.body.congressman_id}/thingflokkar`, {dags: documents.current.date}),
-    ]).then(([congressman, constituency, party]) => ({congressman, constituency, party}));
-
-    if (documents.all && documents.all[0] && documents.all[0].document_id === message.body.document_id && message.body.order === 1) {
-        return mongo.collection('issue')
-            .updateOne({
-                'issue.assembly_id': message.body.assembly_id,
-                'issue.issue_id': message.body.issue_id,
-                'issue.category': message.body.category,
-            }, {
-                $set: {proponent: congressman}
-            }, {
-                upsert: true
-            }).then(result => {
-                if (!result.result.ok) {
-                    throw new Error(`ERROR: DocumentCongressman.addProponentIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
-                }
-                return `DocumentCongressman.addProponentIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+    if (documents.all && documents.all[0] && documents.all[0].document_id === message.body.document_id) {
+        return await Promise.all(documents.congressmen.map(congressmanDocument => {
+            return Promise.all([
+                client(`/samantekt/thingmenn/${congressmanDocument.congressman_id}`),
+                client(`/samantekt/thingmenn/${congressmanDocument.congressman_id}/kjordaemi`, {dags: documents.current.date}),
+                client(`/samantekt/thingmenn/${congressmanDocument.congressman_id}/thingflokkar`, {dags: documents.current.date}),
+                congressmanDocument,
+            ])
+        })).then(all => all.map(([congressman, constituency, party, document]) => ({congressman, constituency, party, document})))
+            .then(proponents => {
+                return mongo.collection('issue')
+                    .updateOne({
+                        'issue.assembly_id': message.body.assembly_id,
+                        'issue.issue_id': message.body.issue_id,
+                        'issue.category': message.body.category,
+                    }, {
+                        $set: {proponents: proponents}
+                    }, {
+                        upsert: true
+                    }).then(result => {
+                        if (!result.result.ok) {
+                            throw new Error(`ERROR: DocumentCongressman.addProponentIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
+                        }
+                        return `DocumentCongressman.addProponentIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+                    });
             });
     }
 
     return Promise.resolve(`DocumentCongressman.addProponentIssue: no-action`);
-};
-
-/**
- * When ever a proponent is added to a document, if it's the initial one, then we can update the proponent's count
- * on the Issue
- *
- * @param message
- * @param mongo
- * @param client
- */
-export const addProponentCountIssue = async (message: Message<CongressmanDocument>, mongo: Db, client: HttpQuery): Promise<any> => {
-    return Promise.all([
-        client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol/${message.body.document_id}`),
-        client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol`),
-        client(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.issue_id}/thingskjol/${message.body.document_id}/thingmenn`)
-    ]).then(async ([document, documents, count]) => {
-
-        if (documents[0] && documents[0].document_id === message.body.document_id) {
-            return mongo.collection('issue')
-                .updateOne({
-                    'issue.assembly_id': message.body.assembly_id,
-                    'issue.issue_id': message.body.issue_id,
-                    'issue.category': message.body.category,
-                }, {
-                    $set: {proponentCount: count}
-                }, {
-                    upsert: true
-                }).then(result => {
-                    if (!result.result.ok) {
-                        throw new Error(`ERROR: DocumentCongressman.addProponentCountIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
-                    }
-                    return `DocumentCongressman.addProponentCountIssue(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
-                });
-        }
-        return Promise.resolve(`DocumentCongressman.addProponentCountIssue: no-action`);
-    });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ Promise.all([
         app.use('issue.category.add', IssueController.addCategory);
 
         app.use('document.add', DocumentController.addDocument);
-        app.use('issue.add.proponents-count', DocumentCongressmanController.addProponentCountIssue);
         app.use('document.add.issue', DocumentController.addDocumentToIssue);
 
         app.use('congressman-document.add', DocumentCongressmanController.addProponentDocument);


### PR DESCRIPTION
## What?
It's better to just put all proponents on an Issue rather counting them. This PR adds that

## How?
Changing `DocumentCongressman.addProponentIssue` function.

## Why?
All the date is required.