### PR TITLE
Changes how this service logs out

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,11 +1,19 @@
 import {Db} from "mongodb";
-import {Client as ElasticsearchClient} from "@elastic/elasticsearch";
+import {ApiResponse, Client as ElasticsearchClient} from "@elastic/elasticsearch";
 
 export type HttpQuery = (url: string, query?: {[key: string]: string | number | Date | null}) => Promise<any>;
 
-export type AppCallback<T> = (message: Message<T>, db: Db, search: ElasticsearchClient, httpQuery?: HttpQuery) => Promise<string>
+export type AppCallback<T> = (message: Message<T>, db: Db, search: ElasticsearchClient, httpQuery?: HttpQuery) => Promise<Result<T>>
 
 export type Message<T> = {body: T, id: string, index: string};
+
+export interface Result<T> {
+    controller: string;
+    action: string;
+    params: T,
+    reason?: string,
+    elasticsearch?: ApiResponse
+}
 
 export interface Speech {
     speech_id:  string

--- a/package-lock.json
+++ b/package-lock.json
@@ -3184,7 +3184,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3202,11 +3203,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3219,15 +3222,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3330,7 +3336,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3340,6 +3347,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3352,17 +3360,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3379,6 +3390,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3451,7 +3463,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3461,6 +3474,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3536,7 +3550,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3566,6 +3581,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3583,6 +3599,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3621,11 +3638,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/__tests__/Mongo.ts
+++ b/src/__tests__/Mongo.ts
@@ -26,8 +26,8 @@ export default class MongoMock {
 
     close = async () => {
         this.db && await this.db.dropDatabase();
-        this.mongo && await this.mongo.close();
-
-        return Promise.resolve();
+        return this.mongo && await this.mongo.close(true, () => {
+            return Promise.resolve();
+        });
     };
 }

--- a/src/__tests__/aggregate/congressman.spec.ts
+++ b/src/__tests__/aggregate/congressman.spec.ts
@@ -70,7 +70,11 @@ describe('incrementAssemblyIssueCount', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            action: 'incrementAssemblyIssueCount',
+            controller: 'Congressman',
+            params: message.body
+        });
     });
 
     test('success - creates new congressman, not primary document', async () => {
@@ -103,7 +107,12 @@ describe('incrementAssemblyIssueCount', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe('Congressman.incrementAssemblyIssueCount no update');
+        expect(response).toEqual({
+            action: 'incrementAssemblyIssueCount',
+            controller: 'Congressman',
+            params: message.body,
+            reason: 'no update',
+        });
     });
 
     test('success - existing congressman, adds document', async () => {
@@ -148,7 +157,11 @@ describe('incrementAssemblyIssueCount', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            action: 'incrementAssemblyIssueCount',
+            controller: 'Congressman',
+            params: message.body
+        });
     });
 
     test('success - existing congressman, increments document', async () => {
@@ -195,7 +208,11 @@ describe('incrementAssemblyIssueCount', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            action: 'incrementAssemblyIssueCount',
+            controller: 'Congressman',
+            params: message.body
+        });
     });
 
     test('success - existing congressman, not primary document', async () => {
@@ -242,7 +259,12 @@ describe('incrementAssemblyIssueCount', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe('Congressman.incrementAssemblyIssueCount no update');
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementAssemblyIssueCount',
+            params: message.body,
+            reason: 'no update'
+        });
     });
 
 });
@@ -306,7 +328,11 @@ describe('addProposition', () => {
         const {_id, ...rest} = congressman[0];
 
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'addProposition',
+            params: message.body
+        });
     });
 
     test('success - not primary document', async () => {
@@ -328,7 +354,12 @@ describe('addProposition', () => {
         const congressman = await mongo.db!.collection('congressman').find({}).toArray();
 
         expect(congressman).toEqual([]);
-        expect(response).toBe(`Congressman.addProposition no update`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'addProposition',
+            params: message.body,
+            reason: 'no update',
+        });
     });
 
     test('success - not primary proponent', async () => {
@@ -350,7 +381,12 @@ describe('addProposition', () => {
         const congressman = await mongo.db!.collection('congressman').find({}).toArray();
 
         expect(congressman).toEqual([]);
-        expect(response).toBe('Congressman.addProposition no update');
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'addProposition',
+            params: message.body,
+            reason: 'no update'
+        });
     });
 
 });
@@ -419,7 +455,11 @@ describe('addSession', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'addSession',
+            params: message.body,
+        });
     });
 });
 
@@ -523,7 +563,11 @@ describe('updateSession', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'updateSession',
+            params: message.body,
+        });
     });
 
     test('no update', async () => {
@@ -607,7 +651,12 @@ describe('updateSession', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.updateSession no update`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'updateSession',
+            params: message.body,
+            reason: 'no update'
+        });
     });
 });
 
@@ -672,7 +721,11 @@ describe('incrementVoteTypeCount', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementVoteTypeCount(1, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementVoteTypeCount',
+            params: message.body,
+        });
     });
 
     test('success existing field', async () => {
@@ -718,7 +771,11 @@ describe('incrementVoteTypeCount', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementVoteTypeCount(1, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementVoteTypeCount',
+            params: message.body,
+        });
     });
 
     test('success - no update', async () => {
@@ -755,7 +812,12 @@ describe('incrementVoteTypeCount', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementVoteTypeCount no update`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementVoteTypeCount',
+            reason: 'no update',
+            params: message.body,
+        });
     });
 });
 
@@ -835,7 +897,11 @@ describe('incrementSuperCategoryCount', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementSuperCategoryCount',
+            params: message.body,
+        });
     });
 
     test('success - existing values', async () => {
@@ -894,10 +960,13 @@ describe('incrementSuperCategoryCount', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementSuperCategoryCount',
+            params: message.body,
+        });
     });
 });
-
 
 describe('incrementSuperCategorySpeechTime', () => {
     const mongo = new MongoMock();
@@ -982,7 +1051,11 @@ describe('incrementSuperCategorySpeechTime', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementSuperCategorySpeechTime',
+            params: message.body,
+        });
     });
 
     test('success - increment', async () => {
@@ -1048,6 +1121,10 @@ describe('incrementSuperCategorySpeechTime', () => {
         const {_id, ...result} = congressman[0];
 
         expect(result).toEqual(expected);
-        expect(response).toBe(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`);
+        expect(response).toEqual({
+            controller: 'Congressman',
+            action: 'incrementSuperCategorySpeechTime',
+            params: message.body,
+        });
     });
 });

--- a/src/__tests__/aggregate/document-congressman.spec.ts
+++ b/src/__tests__/aggregate/document-congressman.spec.ts
@@ -84,8 +84,13 @@ describe('addProponentDocument', () => {
         });
 
         const {_id, ...rest} = document;
-        expect(response).toBe(`DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
+
         expect(rest).toEqual(expected);
+        expect(response).toEqual({
+            controller: 'DocumentCongressman',
+            action: 'addProponentDocument',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {

--- a/src/__tests__/aggregate/document.spec.ts
+++ b/src/__tests__/aggregate/document.spec.ts
@@ -61,7 +61,11 @@ describe('add', () => {
 
         expect(issues.length).toBe(1);
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
+        expect(response).toEqual({
+            controller: 'Document',
+            action: 'add',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {
@@ -167,7 +171,11 @@ describe('addVote', () => {
 
         expect(issues.length).toBe(1);
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`)
+        expect(response).toEqual({
+            controller: 'Document',
+            action: 'addVote',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {

--- a/src/__tests__/aggregate/issue.spec.ts
+++ b/src/__tests__/aggregate/issue.spec.ts
@@ -171,7 +171,11 @@ describe('update', () => {
 
         expect(issues.length).toBe(1);
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'update',
+            params: message.body,
+        });
     });
 });
 
@@ -237,7 +241,11 @@ describe('addGovernmentFlag', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'addGovernmentFlag',
+            params: message.body,
+        });
     });
 
     test('success without flag', async () => {
@@ -268,7 +276,12 @@ describe('addGovernmentFlag', () => {
         const issues = await mongo.db!.collection('issue').find({}).toArray();
 
         expect(issues[0].governmentIssue).toBeFalsy();
-        expect(response).toBe('Issue.addGovernmentFlag no update');
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'addGovernmentFlag',
+            reason: 'no update',
+            params: message.body,
+        });
     });
 });
 
@@ -329,7 +342,11 @@ describe('addDateFlag', () => {
         const issues = await mongo.db!.collection('issue').find({}).toArray();
 
         expect(issues[0].date).toEqual(new Date(`${message.body.date}+00:00`));
-        expect(response).toBe(`Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'addDateFlag',
+            params: message.body,
+        });
     });
 
     test('success without flag', async () => {
@@ -362,7 +379,12 @@ describe('addDateFlag', () => {
         const issues = await mongo.db!.collection('issue').find({}).toArray();
 
         expect(issues[0].date).toBeNull();
-        expect(response).toBe('Issue.addDateFlag no update');
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'addDateFlag',
+            reason: 'no update',
+            params: message.body,
+        });
     });
 });
 
@@ -501,7 +523,11 @@ describe('addCategory', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`)
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'addCategory',
+            params: message.body,
+        });
     })
 });
 
@@ -563,7 +589,11 @@ describe('incrementSpeechCount', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'incrementSpeechCount',
+            params: message.body,
+        });
     });
 
     test('success increment', async () => {
@@ -619,7 +649,11 @@ describe('incrementSpeechCount', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'incrementSpeechCount',
+            params: message.body,
+        });
     });
 });
 
@@ -687,7 +721,11 @@ describe('incrementIssueSpeakerTime', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'incrementIssueSpeakerTime',
+            params: message.body,
+        });
     });
 
     test('success - congressman exists, update time', async () => {
@@ -750,6 +788,10 @@ describe('incrementIssueSpeakerTime', () => {
         const {_id, ...issue} = issues[0];
 
         expect(issue).toEqual(expected);
-        expect(response).toBe(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+        expect(response).toEqual({
+            controller: 'Issue',
+            action: 'incrementIssueSpeakerTime',
+            params: message.body,
+        });
     });
 });

--- a/src/__tests__/aggregate/speech.spec.ts
+++ b/src/__tests__/aggregate/speech.spec.ts
@@ -86,7 +86,11 @@ describe('add', () => {
 
         expect(issues.length).toBe(1);
         expect(rest).toEqual(expected);
-        expect(response).toBe('Speech.add(20010101)');
+        expect(response).toEqual({
+            controller: 'Speech',
+            action: 'add',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {
@@ -238,7 +242,11 @@ describe('update', () => {
 
         expect(issues.length).toBe(1);
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Speech.update(${message.body.speech_id})`);
+        expect(response).toEqual({
+            controller: 'Speech',
+            action: 'update',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {

--- a/src/__tests__/aggregate/vote.spec.ts
+++ b/src/__tests__/aggregate/vote.spec.ts
@@ -75,7 +75,11 @@ describe('add', () => {
 
         expect(issues.length).toBe(1);
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`);
+        expect(response).toEqual({
+            controller: 'Vote',
+            action: 'add',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {
@@ -185,7 +189,11 @@ describe('addItem', () => {
 
         expect(issues.length).toBe(1);
         expect(rest).toEqual(expected);
-        expect(response).toBe(`Vote.addItem(${message.body.vote_id})`);
+        expect(response).toEqual({
+            controller: 'Vote',
+            action: 'addItem',
+            params: message.body,
+        });
     });
 
     test('fail', async () => {

--- a/src/aggregate/congressman.ts
+++ b/src/aggregate/congressman.ts
@@ -52,7 +52,6 @@ export const incrementAssemblySpeechTime: AppCallback<Speech> = async (message, 
 export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
 
     if (!message.body.congressman_id) {
-        // return Promise.resolve('incrementAssemblyIssueCount no update')
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementAssemblyIssueCount',
@@ -80,7 +79,6 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
             if (!result.result.ok) {
                 throw new Error(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
             }
-            // return Promise.resolve(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
             return Promise.resolve({
                 controller: 'Congressman',
                 action: 'incrementAssemblyIssueCount',
@@ -88,7 +86,6 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
             });
         });
     } else {
-        // return Promise.resolve('Congressman.incrementAssemblyIssueCount no update');
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementAssemblyIssueCount',
@@ -114,7 +111,6 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
 export const addProposition: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
 
     if (message.body.order !== 1) {
-        // return Promise.resolve('Congressman.addProposition no update');
         return Promise.resolve({
             controller: 'Congressman',
             action: 'addProposition',
@@ -123,7 +119,6 @@ export const addProposition: AppCallback<CongressmanDocument> = async (message, 
         });
     }
     if (!message.body.congressman_id) {
-        // return Promise.resolve('Congressman.addProposition no update');
         return Promise.resolve({
             controller: 'Congressman',
             action: 'addProposition',
@@ -135,7 +130,6 @@ export const addProposition: AppCallback<CongressmanDocument> = async (message, 
     const documents: Document[] = await client!(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.category}/${message.body.issue_id}/thingskjol`);
 
     if (documents[0].document_id !== message.body.document_id) {
-        // return Promise.resolve('Congressman.addProposition no update');
         return Promise.resolve({
             controller: 'Congressman',
             action: 'addProposition',
@@ -160,7 +154,6 @@ export const addProposition: AppCallback<CongressmanDocument> = async (message, 
         if (!result.result.ok) {
             throw new Error(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`);
         }
-        // return Promise.resolve(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'addProposition',
@@ -209,7 +202,6 @@ export const addSession: AppCallback<Session> = async (message, mongo, elasticse
         if (!result.result.ok) {
             throw new Error(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
         }
-        // return Promise.resolve(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'addSession',
@@ -232,7 +224,6 @@ export const addSession: AppCallback<Session> = async (message, mongo, elasticse
  */
 export const updateSession: AppCallback<Session> = async (message, mongo) => {
     if (!message.body.to) {
-        // return Promise.resolve(`Congressman.updateSession no update`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'updateSession',
@@ -253,7 +244,6 @@ export const updateSession: AppCallback<Session> = async (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
         }
-        // return Promise.resolve(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'updateSession',
@@ -287,7 +277,6 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
     const types = ['boðaði fjarvist', 'fjarverandi', 'greiðir ekki atkvæði', 'já', 'nei'];
 
     if (types.indexOf(message.body.vote) < 0) {
-        // return Promise.resolve(`Congressman.incrementVoteTypeCount no update`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementVoteTypeCount',
@@ -326,7 +315,6 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementVoteTypeCount(${vote.assembly_id}, ${message.body.congressman_id})`);
         }
-        // return Promise.resolve(`Congressman.incrementVoteTypeCount(${vote.assembly_id}, ${message.body.congressman_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementVoteTypeCount',
@@ -349,7 +337,6 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
  */
 export const incrementSuperCategoryCount: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
     if (!message.body.congressman_id) {
-        // return Promise.resolve('incrementSuperCategoryCount no update')
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementSuperCategoryCount',
@@ -387,7 +374,6 @@ export const incrementSuperCategoryCount: AppCallback<CongressmanDocument> = asy
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
         }
-        // return Promise.resolve(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementSuperCategoryCount',
@@ -441,7 +427,6 @@ export const incrementSuperCategorySpeechTime: AppCallback<Speech> = async (mess
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`);
         }
-        // return Promise.resolve(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`)
         return Promise.resolve({
             controller: 'Congressman',
             action: 'incrementSuperCategorySpeechTime',

--- a/src/aggregate/congressman.ts
+++ b/src/aggregate/congressman.ts
@@ -27,7 +27,11 @@ export const incrementAssemblySpeechTime: AppCallback<Speech> = async (message, 
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementAssemblySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`);
         }
-        return Promise.resolve(`Congressman.incrementAssemblySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementAssemblySpeechTime',
+            params: message.body
+        });
     });
 };
 
@@ -48,7 +52,13 @@ export const incrementAssemblySpeechTime: AppCallback<Speech> = async (message, 
 export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
 
     if (!message.body.congressman_id) {
-        return Promise.resolve('incrementAssemblyIssueCount no update')
+        // return Promise.resolve('incrementAssemblyIssueCount no update')
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementAssemblyIssueCount',
+            reason: 'no update',
+            params: message.body
+        });
     }
 
     await createNewCongressmanIfNeeded(mongo, client!, message.body.assembly_id, message.body.congressman_id);
@@ -70,10 +80,21 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
             if (!result.result.ok) {
                 throw new Error(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
             }
-            return Promise.resolve(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
+            // return Promise.resolve(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
+            return Promise.resolve({
+                controller: 'Congressman',
+                action: 'incrementAssemblyIssueCount',
+                params: message.body
+            });
         });
     } else {
-        return Promise.resolve('Congressman.incrementAssemblyIssueCount no update');
+        // return Promise.resolve('Congressman.incrementAssemblyIssueCount no update');
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementAssemblyIssueCount',
+            reason: 'no update',
+            params: message.body
+        });
     }
 };
 
@@ -93,16 +114,34 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
 export const addProposition: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
 
     if (message.body.order !== 1) {
-        return Promise.resolve('Congressman.addProposition no update');
+        // return Promise.resolve('Congressman.addProposition no update');
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'addProposition',
+            reason: 'no update',
+            params: message.body
+        });
     }
     if (!message.body.congressman_id) {
-        return Promise.resolve('Congressman.addProposition no update');
+        // return Promise.resolve('Congressman.addProposition no update');
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'addProposition',
+            reason: 'no update',
+            params: message.body
+        });
     }
 
     const documents: Document[] = await client!(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.category}/${message.body.issue_id}/thingskjol`);
 
     if (documents[0].document_id !== message.body.document_id) {
-        return Promise.resolve('Congressman.addProposition no update');
+        // return Promise.resolve('Congressman.addProposition no update');
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'addProposition',
+            reason: 'no update',
+            params: message.body
+        });
     }
 
     await createNewCongressmanIfNeeded(mongo, client!, message.body.assembly_id, message.body.congressman_id);
@@ -121,7 +160,12 @@ export const addProposition: AppCallback<CongressmanDocument> = async (message, 
         if (!result.result.ok) {
             throw new Error(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`);
         }
-        return Promise.resolve(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`)
+        // return Promise.resolve(`Congressman.addProposition(${message.body.assembly_id}, ${message.body.congressman_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'addProposition',
+            params: message.body
+        });
     });
 };
 
@@ -165,7 +209,12 @@ export const addSession: AppCallback<Session> = async (message, mongo, elasticse
         if (!result.result.ok) {
             throw new Error(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
         }
-        return Promise.resolve(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
+        // return Promise.resolve(`Congressman.addSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'addSession',
+            params: message.body
+        });
     });
 };
 
@@ -183,7 +232,13 @@ export const addSession: AppCallback<Session> = async (message, mongo, elasticse
  */
 export const updateSession: AppCallback<Session> = async (message, mongo) => {
     if (!message.body.to) {
-        return Promise.resolve(`Congressman.updateSession no update`)
+        // return Promise.resolve(`Congressman.updateSession no update`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'updateSession',
+            reason: 'no update',
+            params: message.body
+        });
     }
 
     return mongo.collection('congressman').updateOne({
@@ -198,7 +253,12 @@ export const updateSession: AppCallback<Session> = async (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`);
         }
-        return Promise.resolve(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
+        // return Promise.resolve(`Congressman.updateSession(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.session_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'updateSession',
+            params: message.body
+        });
     });
 };
 
@@ -227,7 +287,13 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
     const types = ['boðaði fjarvist', 'fjarverandi', 'greiðir ekki atkvæði', 'já', 'nei'];
 
     if (types.indexOf(message.body.vote) < 0) {
-        return Promise.resolve(`Congressman.incrementVoteTypeCount no update`)
+        // return Promise.resolve(`Congressman.incrementVoteTypeCount no update`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementVoteTypeCount',
+            reason: 'no update',
+            params: message.body
+        });
     }
 
     const vote: {assembly_id: number} = await client!(`/samantekt/atkvaedi/${message.body.vote_id}`);
@@ -260,7 +326,12 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementVoteTypeCount(${vote.assembly_id}, ${message.body.congressman_id})`);
         }
-        return Promise.resolve(`Congressman.incrementVoteTypeCount(${vote.assembly_id}, ${message.body.congressman_id})`)
+        // return Promise.resolve(`Congressman.incrementVoteTypeCount(${vote.assembly_id}, ${message.body.congressman_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementVoteTypeCount',
+            params: message.body
+        });
     });
 };
 
@@ -278,7 +349,13 @@ export const incrementVoteTypeCount: AppCallback<VoteItem> = async (message, mon
  */
 export const incrementSuperCategoryCount: AppCallback<CongressmanDocument> = async (message, mongo, elasticsearch, client) => {
     if (!message.body.congressman_id) {
-        return Promise.resolve('incrementSuperCategoryCount no update')
+        // return Promise.resolve('incrementSuperCategoryCount no update')
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementSuperCategoryCount',
+            reason: 'no update',
+            params: message.body
+        });
     }
     const superCategories: Array<{super_category_id: number, title: string}> =
         await client!(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.category}/${message.body.issue_id}/yfir-malaflokkar`);
@@ -310,7 +387,12 @@ export const incrementSuperCategoryCount: AppCallback<CongressmanDocument> = asy
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
         }
-        return Promise.resolve(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
+        // return Promise.resolve(`Congressman.incrementSuperCategoryCount(${message.body.assembly_id}, ${message.body.congressman_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementSuperCategoryCount',
+            params: message.body
+        });
     });
 };
 
@@ -359,7 +441,12 @@ export const incrementSuperCategorySpeechTime: AppCallback<Speech> = async (mess
         if (!result.result.ok) {
             throw new Error(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`);
         }
-        return Promise.resolve(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`)
+        // return Promise.resolve(`Congressman.incrementSuperCategorySpeechTime(${message.body.assembly_id}, ${message.body.congressman_id}, ${message.body.speech_id})`)
+        return Promise.resolve({
+            controller: 'Congressman',
+            action: 'incrementSuperCategorySpeechTime',
+            params: message.body
+        });
     });
 };
 

--- a/src/aggregate/document-congressman.ts
+++ b/src/aggregate/document-congressman.ts
@@ -36,7 +36,6 @@ export const addProponentDocument: AppCallback<CongressmanDocument> = async (mes
         if (!result.result.ok) {
             throw new Error(`DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        // return `DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
         return Promise.resolve({
             controller: 'DocumentCongressman',
             action: 'addProponentDocument',

--- a/src/aggregate/document-congressman.ts
+++ b/src/aggregate/document-congressman.ts
@@ -36,6 +36,11 @@ export const addProponentDocument: AppCallback<CongressmanDocument> = async (mes
         if (!result.result.ok) {
             throw new Error(`DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        return `DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        // return `DocumentCongressman.addProponentDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        return Promise.resolve({
+            controller: 'DocumentCongressman',
+            action: 'addProponentDocument',
+            params: message.body
+        });
     });
 };

--- a/src/aggregate/document.ts
+++ b/src/aggregate/document.ts
@@ -27,7 +27,6 @@ export const add: AppCallback<Document> = (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        // return `Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
         return Promise.resolve({
             controller: 'Document',
             action: 'add',
@@ -61,7 +60,6 @@ export const addVote: AppCallback<Vote> = (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        // return `Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
         return Promise.resolve({
             controller: 'Document',
             action: 'addVote',

--- a/src/aggregate/document.ts
+++ b/src/aggregate/document.ts
@@ -27,7 +27,12 @@ export const add: AppCallback<Document> = (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        return `Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        // return `Document.addDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        return Promise.resolve({
+            controller: 'Document',
+            action: 'add',
+            params: message.body
+        });
     });
 };
 
@@ -56,6 +61,11 @@ export const addVote: AppCallback<Vote> = (message, mongo) => {
         if (!result.result.ok) {
             throw new Error(`Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`);
         }
-        return `Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        // return `Document.addVote(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category}, ${message.body.document_id})`;
+        return Promise.resolve({
+            controller: 'Document',
+            action: 'addVote',
+            params: message.body
+        });
     });
 };

--- a/src/aggregate/issue.ts
+++ b/src/aggregate/issue.ts
@@ -31,7 +31,12 @@ export const add: AppCallback<Issue> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'add',
+                params: message.body
+            });
         });
 };
 
@@ -56,7 +61,12 @@ export const update: AppCallback<Issue> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'update',
+                params: message.body
+            });
         });
 };
 
@@ -84,10 +94,21 @@ export const addGovernmentFlag: AppCallback<Document> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'addGovernmentFlag',
+                params: message.body
+            });
         });
     } else {
-        return Promise.resolve('Issue.addGovernmentFlag no update');
+        // return Promise.resolve('Issue.addGovernmentFlag no update');
+        return Promise.resolve({
+            controller: 'Issue',
+            action: 'addGovernmentFlag',
+            reason: 'no update',
+            params: message.body
+        });
     }
 };
 
@@ -120,10 +141,21 @@ export const addDateFlag: AppCallback<Document> = async (message, mongo, elastic
             if (!result.result.ok) {
                 throw new Error(`Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'addDateFlag',
+                params: message.body
+            });
         });
     } else {
-        return Promise.resolve('Issue.addDateFlag no update')
+        // return Promise.resolve('Issue.addDateFlag no update')
+        return Promise.resolve({
+            controller: 'Issue',
+            action: 'addDateFlag',
+            reason: 'no update',
+            params: message.body
+        });
     }
 };
 
@@ -163,10 +195,22 @@ export const addProponent: AppCallback<CongressmanDocument> = async (message, mo
                 if (!result.result.ok) {
                     throw new Error(`Issue.addProponent(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
                 }
-                return `Issue.addProponent(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+                // return `Issue.addProponent(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+                return Promise.resolve({
+                    controller: 'Issue',
+                    action: 'addProponent',
+                    reason: 'no update',
+                    params: message.body
+                });
             })
     } else {
-        return Promise.resolve('Issue.addProponent no update');
+        // return Promise.resolve('Issue.addProponent no update');
+        return Promise.resolve({
+            controller: 'Issue',
+            action: 'addProponent',
+            reason: 'no update',
+            params: message.body
+        });
     }
 };
 
@@ -202,7 +246,12 @@ export const addCategory: AppCallback<IssueCategory> = async (message, mongo, el
             if (!result.result.ok) {
                 throw new Error(`Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'addCategory',
+                params: message.body
+            });
         });
 };
 
@@ -231,7 +280,12 @@ export const incrementSpeechCount: AppCallback<Speech> = async (message, mongo) 
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'incrementSpeechCount',
+                params: message.body
+            });
         });
 
 };
@@ -285,7 +339,12 @@ export const incrementIssueSpeakerTime: AppCallback<Speech> = async (message, mo
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'incrementIssueSpeakerTime',
+                params: message.body
+            });
         });
 
     } else {
@@ -311,7 +370,12 @@ export const incrementIssueSpeakerTime: AppCallback<Speech> = async (message, mo
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            // return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'incrementIssueSpeakerTime',
+                params: message.body
+            });
         });
     }
 };
@@ -320,9 +384,8 @@ export const incrementIssueSpeakerTime: AppCallback<Speech> = async (message, mo
  *
  * @param message
  * @param mongo
- * @param client
  */
-export const addLink: AppCallback<IssueLink> = async (message, mongo, client) => {
+export const addLink: AppCallback<IssueLink> = async (message, mongo) => {
     return mongo.collection('issue')
         .updateOne({
             'assembly.assembly_id': message.body.from_assembly_id,
@@ -342,6 +405,11 @@ export const addLink: AppCallback<IssueLink> = async (message, mongo, client) =>
             if (!result.result.ok) {
                 throw new Error(`Issue.add(${message.body.from_assembly_id}, ${message.body.from_issue_id}, ${message.body.from_category})`);
             }
-            return `Issue.addLink(${message.body.from_assembly_id}, ${message.body.from_issue_id}, ${message.body.from_category})`;
+            // return `Issue.addLink(${message.body.from_assembly_id}, ${message.body.from_issue_id}, ${message.body.from_category})`;
+            return Promise.resolve({
+                controller: 'Issue',
+                action: 'addLink',
+                params: message.body
+            });
         });
 };

--- a/src/aggregate/issue.ts
+++ b/src/aggregate/issue.ts
@@ -31,7 +31,6 @@ export const add: AppCallback<Issue> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'add',
@@ -61,7 +60,6 @@ export const update: AppCallback<Issue> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.update(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'update',
@@ -94,7 +92,6 @@ export const addGovernmentFlag: AppCallback<Document> = (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.addGovernmentFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'addGovernmentFlag',
@@ -102,7 +99,6 @@ export const addGovernmentFlag: AppCallback<Document> = (message, mongo) => {
             });
         });
     } else {
-        // return Promise.resolve('Issue.addGovernmentFlag no update');
         return Promise.resolve({
             controller: 'Issue',
             action: 'addGovernmentFlag',
@@ -141,7 +137,6 @@ export const addDateFlag: AppCallback<Document> = async (message, mongo, elastic
             if (!result.result.ok) {
                 throw new Error(`Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'addDateFlag',
@@ -149,7 +144,6 @@ export const addDateFlag: AppCallback<Document> = async (message, mongo, elastic
             });
         });
     } else {
-        // return Promise.resolve('Issue.addDateFlag no update')
         return Promise.resolve({
             controller: 'Issue',
             action: 'addDateFlag',
@@ -195,7 +189,6 @@ export const addProponent: AppCallback<CongressmanDocument> = async (message, mo
                 if (!result.result.ok) {
                     throw new Error(`Issue.addProponent(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
                 }
-                // return `Issue.addProponent(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
                 return Promise.resolve({
                     controller: 'Issue',
                     action: 'addProponent',
@@ -204,7 +197,6 @@ export const addProponent: AppCallback<CongressmanDocument> = async (message, mo
                 });
             })
     } else {
-        // return Promise.resolve('Issue.addProponent no update');
         return Promise.resolve({
             controller: 'Issue',
             action: 'addProponent',
@@ -246,7 +238,6 @@ export const addCategory: AppCallback<IssueCategory> = async (message, mongo, el
             if (!result.result.ok) {
                 throw new Error(`Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.addCategory(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'addCategory',
@@ -280,7 +271,6 @@ export const incrementSpeechCount: AppCallback<Speech> = async (message, mongo) 
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.incrementSpeechCount(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'incrementSpeechCount',
@@ -339,7 +329,6 @@ export const incrementIssueSpeakerTime: AppCallback<Speech> = async (message, mo
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'incrementIssueSpeakerTime',
@@ -370,7 +359,6 @@ export const incrementIssueSpeakerTime: AppCallback<Speech> = async (message, mo
             if (!result.result.ok) {
                 throw new Error(`Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
-            // return `Issue.incrementIssueSpeakerTime(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'incrementIssueSpeakerTime',
@@ -405,7 +393,6 @@ export const addLink: AppCallback<IssueLink> = async (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Issue.add(${message.body.from_assembly_id}, ${message.body.from_issue_id}, ${message.body.from_category})`);
             }
-            // return `Issue.addLink(${message.body.from_assembly_id}, ${message.body.from_issue_id}, ${message.body.from_category})`;
             return Promise.resolve({
                 controller: 'Issue',
                 action: 'addLink',

--- a/src/aggregate/speech.ts
+++ b/src/aggregate/speech.ts
@@ -37,7 +37,6 @@ export const add: AppCallback<Speech> = async (message, mongo, elasticsearch, cl
             if (!result.result.ok) {
                 throw new Error(`Speech.add(${message.body.speech_id})`);
             }
-            // return `Speech.add(${message.body.speech_id})`;
             return Promise.resolve({
                 controller: 'Speech',
                 action: 'add',
@@ -71,7 +70,6 @@ export const update: AppCallback<Speech> = async (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Speech.update(${message.body.speech_id})`);
             }
-            // return `Speech.update(${message.body.speech_id})`;
             return Promise.resolve({
                 controller: 'Speech',
                 action: 'update',

--- a/src/aggregate/speech.ts
+++ b/src/aggregate/speech.ts
@@ -37,7 +37,12 @@ export const add: AppCallback<Speech> = async (message, mongo, elasticsearch, cl
             if (!result.result.ok) {
                 throw new Error(`Speech.add(${message.body.speech_id})`);
             }
-            return `Speech.add(${message.body.speech_id})`;
+            // return `Speech.add(${message.body.speech_id})`;
+            return Promise.resolve({
+                controller: 'Speech',
+                action: 'add',
+                params: message.body
+            });
         });
 };
 
@@ -66,6 +71,11 @@ export const update: AppCallback<Speech> = async (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Speech.update(${message.body.speech_id})`);
             }
-            return `Speech.update(${message.body.speech_id})`;
+            // return `Speech.update(${message.body.speech_id})`;
+            return Promise.resolve({
+                controller: 'Speech',
+                action: 'update',
+                params: message.body
+            });
         });
 };

--- a/src/aggregate/vote.ts
+++ b/src/aggregate/vote.ts
@@ -29,7 +29,12 @@ export const add: AppCallback<Vote> = async (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`);
             }
-            return `Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`;
+            // return `Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`;
+            return Promise.resolve({
+                controller: 'Vote',
+                action: 'add',
+                params: message.body
+            });
         });
 };
 
@@ -71,6 +76,11 @@ export const addItem: AppCallback<VoteItem> = async (message, mongo, elasticsear
             if (!result.result.ok) {
                 throw new Error(`Vote.addItem(${message.body.vote_id})`);
             }
-            return `Vote.addItem(${message.body.vote_id})`;
+            // return `Vote.addItem(${message.body.vote_id})`;
+            return Promise.resolve({
+                controller: 'Vote',
+                action: 'addItem',
+                params: message.body
+            });
         });
 };

--- a/src/aggregate/vote.ts
+++ b/src/aggregate/vote.ts
@@ -29,7 +29,6 @@ export const add: AppCallback<Vote> = async (message, mongo) => {
             if (!result.result.ok) {
                 throw new Error(`Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`);
             }
-            // return `Vote.add(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.document_id})`;
             return Promise.resolve({
                 controller: 'Vote',
                 action: 'add',
@@ -76,7 +75,6 @@ export const addItem: AppCallback<VoteItem> = async (message, mongo, elasticsear
             if (!result.result.ok) {
                 throw new Error(`Vote.addItem(${message.body.vote_id})`);
             }
-            // return `Vote.addItem(${message.body.vote_id})`;
             return Promise.resolve({
                 controller: 'Vote',
                 action: 'addItem',

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,13 +26,38 @@ export default class App {
         });
     }
 
+/*
+{
+    log_level: string
+    queue: string
+    content: json
+    error_message: string
+    reason: dead-letter-exchange | requeue | initialize | success | error
+
+
+    controller
+    action
+    params
+}
+ */
+
     use<T>(queue: string, callback: AppCallback<T>) {
         if (!this._channel) {
             return;
         }
         this._channel.assertQueue(queue, this._options)
             .then(() => {
-                console.log(`DEBUG:(${queue}) initialize`);
+                // console.log(`DEBUG:(${queue}) initialize`);
+                console.log(JSON.stringify({
+                    log_level: 'DEBUG',
+                    queue: queue,
+                    content: null,
+                    error_message: null,
+                    reason: 'initialize',
+                    controller: null,
+                    action: null,
+                    params: {},
+                }));
                 return this._channel!.consume(queue, (msg: ConsumeMessage | null) => {
                     if (msg !== null) {
                         try {
@@ -40,25 +65,73 @@ export default class App {
                             callback(message, this._mongo, this._elasticsearch, this._httpQuery)
                                 .then(result => {
                                     this._channel!.ack(msg);
-                                    console.log(`INFO:(${queue}) ${result}`)
+                                    // console.log(`INFO:(${queue}) ${result}`)
+                                    console.log(JSON.stringify({
+                                        log_level: 'INFO',
+                                        queue: queue,
+                                        content: JSON.parse(msg.content.toString()),
+                                        error_message: null,
+                                        reason: 'success',
+                                        ...result
+                                    }));
                                 })
                                 .catch(error => {
                                     if (msg.fields.redelivered) {
                                         this._channel!.nack(msg, undefined, false);
-                                        console.error(`WARN:(${queue}) -> dead-letter-exchange | ${error && error.message} | ${msg.content.toString()}`);
+                                        // console.error(`WARN:(${queue}) -> dead-letter-exchange | ${error && error.message} | ${msg.content.toString()}`);
+                                        console.log(JSON.stringify({
+                                            log_level: 'WARN',
+                                            queue: queue,
+                                            content: JSON.parse(msg.content.toString()),
+                                            error_message: error && error.message,
+                                            reason: 'dead-letter-exchange',
+                                            controller: null,
+                                            action: null,
+                                            params: {},
+                                        }));
                                     } else {
                                         this._channel!.nack(msg, undefined, true);
-                                        console.log(`DEBUG:(${queue}) -> requeue | ${error && error.message} | ${msg.content.toString()}`);
+                                        // console.log(`DEBUG:(${queue}) -> requeue | ${error && error.message} | ${msg.content.toString()}`);
+                                        console.log(JSON.stringify({
+                                            log_level: 'DEBUG',
+                                            queue: queue,
+                                            content: JSON.parse(msg.content.toString()),
+                                            error_message: error && error.message,
+                                            reason: 'requeue',
+                                            controller: null,
+                                            action: null,
+                                            params: {},
+                                        }));
                                     }
                                 });
                         } catch (e) {
                             this._channel!.ack(msg);
-                            console.log(`ERROR:(${queue}) ${e.message} | ${msg && msg.content && msg.content.toString()}`);
+                            // console.log(`ERROR:(${queue}) ${e.message} | ${msg && msg.content && msg.content.toString()}`);
+                            console.log(JSON.stringify({
+                                log_level: 'ERROR',
+                                queue: queue,
+                                content: JSON.parse(msg.content.toString()),
+                                error_message: e && e.message,
+                                reason: 'error',
+                                controller: null,
+                                action: null,
+                                params: {},
+                            }));
                         }
                     }
                 })
-            }).catch(error => {
-                console.error(`ALERT:(${queue}) ${error.message}`);
+            }).catch((error: Error) => {
+                // console.error(`ALERT:(${queue}) ${error.message}`);
+                console.log(JSON.stringify({
+                    log_level: 'ALERT',
+                    queue: queue,
+                    content: null,
+                    error_message: error && error.message,
+                    reason: 'error',
+                    controller: null,
+                    action: null,
+                    params: {},
+                }));
             })
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,28 +26,12 @@ export default class App {
         });
     }
 
-/*
-{
-    log_level: string
-    queue: string
-    content: json
-    error_message: string
-    reason: dead-letter-exchange | requeue | initialize | success | error
-
-
-    controller
-    action
-    params
-}
- */
-
     use<T>(queue: string, callback: AppCallback<T>) {
         if (!this._channel) {
             return;
         }
         this._channel.assertQueue(queue, this._options)
             .then(() => {
-                // console.log(`DEBUG:(${queue}) initialize`);
                 console.log(JSON.stringify({
                     log_level: 'DEBUG',
                     queue: queue,
@@ -65,7 +49,6 @@ export default class App {
                             callback(message, this._mongo, this._elasticsearch, this._httpQuery)
                                 .then(result => {
                                     this._channel!.ack(msg);
-                                    // console.log(`INFO:(${queue}) ${result}`)
                                     console.log(JSON.stringify({
                                         log_level: 'INFO',
                                         queue: queue,
@@ -78,7 +61,6 @@ export default class App {
                                 .catch(error => {
                                     if (msg.fields.redelivered) {
                                         this._channel!.nack(msg, undefined, false);
-                                        // console.error(`WARN:(${queue}) -> dead-letter-exchange | ${error && error.message} | ${msg.content.toString()}`);
                                         console.log(JSON.stringify({
                                             log_level: 'WARN',
                                             queue: queue,
@@ -91,7 +73,6 @@ export default class App {
                                         }));
                                     } else {
                                         this._channel!.nack(msg, undefined, true);
-                                        // console.log(`DEBUG:(${queue}) -> requeue | ${error && error.message} | ${msg.content.toString()}`);
                                         console.log(JSON.stringify({
                                             log_level: 'DEBUG',
                                             queue: queue,
@@ -106,7 +87,6 @@ export default class App {
                                 });
                         } catch (e) {
                             this._channel!.ack(msg);
-                            // console.log(`ERROR:(${queue}) ${e.message} | ${msg && msg.content && msg.content.toString()}`);
                             console.log(JSON.stringify({
                                 log_level: 'ERROR',
                                 queue: queue,
@@ -121,7 +101,6 @@ export default class App {
                     }
                 })
             }).catch((error: Error) => {
-                // console.error(`ALERT:(${queue}) ${error.message}`);
                 console.log(JSON.stringify({
                     log_level: 'ALERT',
                     queue: queue,

--- a/src/search/issue.ts
+++ b/src/search/issue.ts
@@ -13,6 +13,12 @@ export const add: AppCallback<Issue> = (message, _, search) => {
         index: message.index,
         body: message.body
     }).then(result => {
-        return Promise.resolve(`Issue.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
+        // return Promise.resolve(`Issue.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
+        return Promise.resolve({
+            controller: 'Issue',
+            action: 'add',
+            params: message.body,
+            elasticsearch: result
+        });
     });
 };

--- a/src/search/issue.ts
+++ b/src/search/issue.ts
@@ -13,7 +13,6 @@ export const add: AppCallback<Issue> = (message, _, search) => {
         index: message.index,
         body: message.body
     }).then(result => {
-        // return Promise.resolve(`Issue.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
         return Promise.resolve({
             controller: 'Issue',
             action: 'add',

--- a/src/search/speech.ts
+++ b/src/search/speech.ts
@@ -17,6 +17,12 @@ export const add: AppCallback<Speech> = (message, _, search) => {
             to: new Date(`${message.body.to}+00:00`),
         }
     }).then(result => {
-        return Promise.resolve(`Speech.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
+        // return Promise.resolve(`Speech.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
+        return Promise.resolve({
+            controller: 'Speech',
+            action: 'add',
+            params: message.body,
+            elasticsearch: result
+        });
     });
 };

--- a/src/search/speech.ts
+++ b/src/search/speech.ts
@@ -17,7 +17,6 @@ export const add: AppCallback<Speech> = (message, _, search) => {
             to: new Date(`${message.body.to}+00:00`),
         }
     }).then(result => {
-        // return Promise.resolve(`Speech.add(${message.id}:${message.index}:${result.statusCode}:${result.body.result}|${result.warnings})`);
         return Promise.resolve({
             controller: 'Speech',
             action: 'add',


### PR DESCRIPTION
## What?
It makes more sense that the logging string produced by this service should be a JSON rather than something that needs to be RegEx'ed... this PR changes that

## How?
By creating an `interface` that should be returned by the each successful controller/action

```ts
export interface Result<T> {
    controller: string;
    action: string;
    params: T,
    reason?: string,
    elasticsearch?: ApiResponse
}
```
## Why?
So it's simpler to pars end send to Logstash/Elasticsearch