### PR TITLE
Congressman type structure change

### DIFF
--- a/config/rabbitmq/definitions.json
+++ b/config/rabbitmq/definitions.json
@@ -82,7 +82,7 @@
         },
         {
             "arguments": {},
-            "destination": "a.issue.date-flag",
+            "destination": "a.issue.primary-document",
             "destination_type": "queue",
             "routing_key": "document.add",
             "source": "aggregate",
@@ -421,7 +421,7 @@
             "arguments": {"x-dead-letter-exchange": "dlq.aggregate.exchange"},
             "auto_delete": false,
             "durable": true,
-            "name": "a.issue.date-flag",
+            "name": "a.issue.primary-document",
             "vhost": "/"
         },
         {

--- a/src/__tests__/aggregate/congressman.spec.ts
+++ b/src/__tests__/aggregate/congressman.spec.ts
@@ -60,7 +60,13 @@ describe('incrementAssemblyIssueCount', () => {
             },
             speech_time: 0,
             issues: {
-                a: 1
+                a: {
+                    type:  'a',
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                    count: 1
+                }
             },
         };
 
@@ -146,7 +152,13 @@ describe('incrementAssemblyIssueCount', () => {
                 assembly_id: message.body.assembly_id
             },
             issues: {
-                c: 1
+                c: {
+                    type: 'c',
+                    count: 1,
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                }
             },
         };
 
@@ -186,7 +198,13 @@ describe('incrementAssemblyIssueCount', () => {
                 assembly_id: message.body.assembly_id
             },
             issues: {
-                c: 1
+                c: {
+                    type: 'c',
+                    count: 1,
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                }
             },
         };
         const expected = {
@@ -197,7 +215,13 @@ describe('incrementAssemblyIssueCount', () => {
                 assembly_id: message.body.assembly_id
             },
             issues: {
-                c: 2
+                c: {
+                    type: 'c',
+                    count: 2,
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                }
             },
         };
 
@@ -237,7 +261,13 @@ describe('incrementAssemblyIssueCount', () => {
                 assembly_id: message.body.assembly_id
             },
             issues: {
-                c: 2
+                c: {
+                    type: 'c',
+                    count: 2,
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                }
             },
         };
         const expected = {
@@ -248,7 +278,13 @@ describe('incrementAssemblyIssueCount', () => {
                 assembly_id: message.body.assembly_id
             },
             issues: {
-                c: 2
+                c: {
+                    type: 'c',
+                    count: 2,
+                    category: null,
+                    typeName: null,
+                    typeSubName: null,
+                }
             },
         };
 

--- a/src/aggregate/congressman.ts
+++ b/src/aggregate/congressman.ts
@@ -1,5 +1,16 @@
-import {AppCallback, CongressmanDocument, Issue, Speech, Document, Session, VoteItem, HttpQuery} from "../../@types";
+import {
+    AppCallback,
+    CongressmanDocument,
+    Issue,
+    Speech,
+    Document,
+    Session,
+    VoteItem,
+    HttpQuery,
+    Constituency, Party
+} from "../../@types";
 import {Db, InsertOneWriteOpResult} from "mongodb";
+import Maybe = jest.Maybe;
 
 /**
  * Increment speech times for a Congressman in an Assembly.
@@ -39,6 +50,8 @@ export const incrementAssemblySpeechTime: AppCallback<Speech> = async (message, 
  * When a proponent is added to an issue (if that congressman is on the primary document), the congressman collection
  * is updated adding a record that is bound to the congressman ID and the assembly ID and the counter for that
  * Issue type (a, l, m, ...) is incremented.
+ *
+ * If it is not the primary document, then the `motions` object is incremented on the bases of the document-type
  *
  * @client: fetch congressman (if not present)
  *         fetch all documents by issue
@@ -97,11 +110,25 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
             });
         });
     } else {
-        return Promise.resolve({
-            controller: 'Congressman',
-            action: 'incrementAssemblyIssueCount',
-            reason: 'no update',
-            params: message.body
+        const document: Maybe<Document> = documents.find(doc => doc.document_id === message.body.document_id);
+        return mongo.collection('congressman').updateOne({
+            'congressman.congressman_id': message.body.congressman_id,
+            'assembly.assembly_id': message.body.assembly_id,
+        }, {
+            $inc: {
+                [`motions.${(document && document.type) || 'oflokkad'}`]: 1
+            }
+        }, {
+            upsert: true
+        }).then(result => {
+            if (!result.result.ok) {
+                throw new Error(`Congressman.incrementAssemblyIssueCount(${message.body.assembly_id}, ${message.body.congressman_id})`);
+            }
+            return Promise.resolve({
+                controller: 'Congressman',
+                action: 'incrementAssemblyIssueCount',
+                params: message.body
+            });
         });
     }
 };
@@ -183,27 +210,21 @@ export const addProposition: AppCallback<CongressmanDocument> = async (message, 
  * @param mongo
  * @param elasticsearch
  * @param client
- *
- * @todo Fetch full party info
- * @todo Fetch full constituency info
- * @todo Not attached to a queue
  */
 export const addSession: AppCallback<Session> = async (message, mongo, elasticsearch, client) => {
-    // need to get party
-    // need to get constituency
-    // await Promise.all([
-    //     client(party),
-    //     client(constituency),
-    // ]);
-
     await createNewCongressmanIfNeeded(mongo, client!, message.body.assembly_id, message.body.congressman_id);
+
+    const constituency: Constituency = await client!(`/samantekt/kjordaemi/${message.body.constituency_id}`);
+    const party: Party = await client!(`/samantekt/thingflokkar/${message.body.party_id}`);
 
     return mongo.collection('congressman').updateOne({
         'congressman.congressman_id': message.body.congressman_id,
         'assembly.assembly_id': message.body.assembly_id,
     }, {
         $addToSet: {
-            'sessions':  {
+            constituencies: constituency,
+            parties: party,
+            sessions:  {
                 ...message.body,
                 from: new Date(`${message.body.from} 00:00:00+00:00`),
                 to: message.body.to ? new Date(`${message.body.to} 00:00:00+00:00`) : null,
@@ -230,8 +251,6 @@ export const addSession: AppCallback<Session> = async (message, mongo, elasticse
  *
  * @param message
  * @param mongo
- *
- * @todo Not attached to a queue
  */
 export const updateSession: AppCallback<Session> = async (message, mongo) => {
     if (!message.body.to) {

--- a/src/aggregate/congressman.ts
+++ b/src/aggregate/congressman.ts
@@ -66,13 +66,24 @@ export const incrementAssemblyIssueCount: AppCallback<CongressmanDocument> = asy
 
     if (documents[0].document_id === message.body.document_id) {
         const issue: Issue = await client!(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.category}/${message.body.issue_id}`);
+
+        const type = {
+            [`issues.${issue.type}.type`]:  issue.type,
+            [`issues.${issue.type}.category`]: issue.category,
+            [`issues.${issue.type}.typeName`]: issue.type_name,
+            [`issues.${issue.type}.typeSubName`]: issue.type_subname,
+        };
+
+        const counts = {
+            [`issues.${issue.type}.count`]: 1,
+        };
+
         return mongo.collection('congressman').updateOne({
             'congressman.congressman_id': message.body.congressman_id,
             'assembly.assembly_id': message.body.assembly_id,
         }, {
-            $inc: {
-                [`issues.${issue.type}`]: 1,
-            }
+            $set: type,
+            $inc: counts
         }, {
             upsert: true
         }).then(result => {

--- a/src/aggregate/issue.ts
+++ b/src/aggregate/issue.ts
@@ -119,7 +119,7 @@ export const addGovernmentFlag: AppCallback<Document> = (message, mongo) => {
  * @param elasticsearch
  * @param client
  */
-export const addDateFlag: AppCallback<Document> = async (message, mongo, elasticsearch, client) => {
+export const addPrimaryDocument: AppCallback<Document> = async (message, mongo, elasticsearch, client) => {
     const documents = await client!(`/samantekt/loggjafarthing/${message.body.assembly_id}/thingmal/${message.body.category}/${message.body.issue_id}/thingskjol`);
     if (documents[0].document_id === message.body.document_id) {
         return mongo.collection('issue').updateOne({
@@ -130,23 +130,25 @@ export const addDateFlag: AppCallback<Document> = async (message, mongo, elastic
         }, {
             $set: {
                 date: (message.body.date && new Date(`${message.body.date}+00:00`)) || null,
+                document_type: message.body.type,
+                document_url: message.body.url,
             }
         }, {
             upsert: true
         }).then(result => {
             if (!result.result.ok) {
-                throw new Error(`Issue.addDateFlag(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
+                throw new Error(`Issue.addPrimaryDocument(${message.body.assembly_id}, ${message.body.issue_id}, ${message.body.category})`);
             }
             return Promise.resolve({
                 controller: 'Issue',
-                action: 'addDateFlag',
+                action: 'addPrimaryDocument',
                 params: message.body
             });
         });
     } else {
         return Promise.resolve({
             controller: 'Issue',
-            action: 'addDateFlag',
+            action: 'addPrimaryDocument',
             reason: 'no update',
             params: message.body
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ Promise.all([
 
         /* document.add             -> */  app.use<Document>('a.document.add', AggregateDocumentController.add);
         /* document.add             -> */  app.use<Document>('a.issue.government-flag', AggregateIssueController.addGovernmentFlag);
-        /* document.add             -> */  app.use<Document>('a.issue.date-flag', AggregateIssueController.addDateFlag);
+        /* document.add             -> */  app.use<Document>('a.issue.primary-document', AggregateIssueController.addPrimaryDocument);
 
         /* congressman-document.add -> */  app.use<CongressmanDocument>('a.congressman-document.add', AggregateDocumentCongressmanController.addProponentDocument);
         /* congressman-document.add -> */  app.use<CongressmanDocument>('a.congressman.increment-assembly-issue-count', AggregateCongressmanController.incrementAssemblyIssueCount);


### PR DESCRIPTION
## What?
Adds the full data-type for issue when a congressman is the first proponent (previously it only showed the letter that represents `l`|`a`...)

Counts congressman interactions to non-primary documents (breytingartillögur ...)

Adds the party and constituency info to a congressman when a session is added. 

## How?
Changes the lambda functions and tests

## Why?
To be able to show more data for Congressman